### PR TITLE
Add check for out-of-bounds

### DIFF
--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.cpp
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.cpp
@@ -68,6 +68,8 @@ void LilygoT547Display::flush_screen_changes() {
 void LilygoT547Display::on_shutdown() { eink_deinit(); }
 
 void HOT LilygoT547Display::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
   bool c = convert_color(color);
   eink_set_pixel(x, y, c, fb);
 }


### PR DESCRIPTION
Check whether a requested pixel is out-of-bounds, and avoid drawing in case it is off-screen.

# What does this implement/fix?

If someone tries to draw a pixel outside the screen bounds, the device crashes. Added a check to prevent that, like e.g. the inkplate device has.
This might have a (slight) performance impact; I don't have a device myself with which I could test that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
