### PR TITLE
Update lilygo_t5_47_display.h

### DIFF
--- a/esphome/components/lilygo_t5_47/display/__init__.py
+++ b/esphome/components/lilygo_t5_47/display/__init__.py
@@ -45,7 +45,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 

--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace lilygo_t5_47 {
 
-class LilygoT547Display : public PollingComponent, public display::DisplayBuffer {
+class LilygoT547Display : public PollingComponent, public display::Display {
  public:
   float get_setup_priority() const override;
 

--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace lilygo_t5_47 {
 
-class LilygoT547Display : public PollingComponent, public display::Display, public Component {
+class LilygoT547Display : public display::Display {
  public:
   float get_setup_priority() const override;
 

--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace lilygo_t5_47 {
 
-class LilygoT547Display : public PollingComponent, public display::Display {
+class LilygoT547Display : public PollingComponent, public display::Display, public Component {
  public:
   float get_setup_priority() const override;
 

--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
@@ -6,6 +6,7 @@
 #include "esphome/components/display/display_color_utils.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/version.h"
 
 namespace esphome {
 namespace lilygo_t5_47 {
@@ -43,6 +44,9 @@ class LilygoT547Display : public PollingComponent, public display::DisplayBuffer
   void flush_screen_changes();
   void power_on();
   void power_off();
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2022,6,0)
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+#endif
 
  protected:
   void HOT draw_absolute_pixel_internal(int x, int y, Color color) override;


### PR DESCRIPTION
Make the always-on branch compatible with ESPHome 2022.6+

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
