### PR TITLE
Fix for esphome 2023.12.x

### DIFF
--- a/esphome/components/lilygo_t5_47/display/__init__.py
+++ b/esphome/components/lilygo_t5_47/display/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_PAGES,
 )
+from esphome.const import __version__ as ESPHOME_VERSION
 
 from .. import lilygo_t5_47_ns
 
@@ -33,7 +34,9 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
+        
     await display.register_display(var, config)
 
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))

--- a/esphome/components/lilygo_t5_47/display/__init__.py
+++ b/esphome/components/lilygo_t5_47/display/__init__.py
@@ -49,7 +49,7 @@ async def to_code(config):
         )
         cg.add(var.set_writer(lambda_))
 
-    cg.add_library("https://github.com/ashald/platformio-epdiy-monochrome.git", None)
+    cg.add_library("https://github.com/daernsinstantfortress/platformio-epdiy-monochrome.git", None)
 
     cg.add_build_flag("-DCONFIG_EPD_DISPLAY_TYPE_ED047TC1")
     cg.add_build_flag("-DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47")

--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
@@ -11,7 +11,11 @@
 namespace esphome {
 namespace lilygo_t5_47 {
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class LilygoT547Display : public display::DisplayBuffer {
+#else 
 class LilygoT547Display : public PollingComponent, public display::DisplayBuffer {
+#endif
  public:
   float get_setup_priority() const override;
 

--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <Arduino.h>
 
-#include "esp_adc_cal.h"
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/display/display_color_utils.h"
 #include "esphome/core/component.h"

--- a/esphome/components/lilygo_t5_47/sensor/__init__.py
+++ b/esphome/components/lilygo_t5_47/sensor/__init__.py
@@ -32,7 +32,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     await sensor.register_sensor(var, config)
 
-    cg.add_library("https://github.com/ashald/platformio-epdiy-monochrome.git", None)
+    cg.add_library("https://github.com/daernsinstantfortress/platformio-epdiy-monochrome.git", None)
 
     cg.add_build_flag("-DCONFIG_EPD_DISPLAY_TYPE_ED047TC1")
     cg.add_build_flag("-DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47")

--- a/esphome/components/lilygo_t5_47/sensor/lilygo_t5_47_sensor.cpp
+++ b/esphome/components/lilygo_t5_47/sensor/lilygo_t5_47_sensor.cpp
@@ -10,19 +10,24 @@ namespace lilygo_t5_47 {
 
 static const char *const TAG = "lilygo_t5_47.sensor";
 
-static int correct_adc_reference() {
-  esp_adc_cal_characteristics_t adc_chars;
-  esp_adc_cal_value_t val_type = esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12, 1100, &adc_chars);
-  if (val_type == ESP_ADC_CAL_VAL_EFUSE_VREF) {
-    return adc_chars.vref;
-  }
-  return 1100;
-}
-
 float LilygoT547Sensor::get_battery_voltage() {
-  int vref = correct_adc_reference();
-  int v = analogRead(36);
-  return ((float) v / 4095.0) * 2.0 * 3.3 * (vref / 1000.0);
+  int raw = analogRead(36);
+
+  adc_cali_handle_t cali_handle = NULL;
+  adc_cali_line_fitting_config_t cali_config = {
+      .unit_id = ADC_UNIT_1,
+      .atten = ADC_ATTEN_DB_12,
+      .bitwidth = ADC_BITWIDTH_12,
+      .default_vref = 1100,
+  };
+
+  int voltage_mv = 0;
+  if (adc_cali_create_scheme_line_fitting(&cali_config, &cali_handle) == ESP_OK) {
+    adc_cali_raw_to_voltage(cali_handle, raw, &voltage_mv);
+    adc_cali_delete_scheme_line_fitting(cali_handle);
+    return voltage_mv / 1000.0f * 2.0f;
+  }
+  return ((float) raw / 4095.0f) * 2.0f * 3.3f;
 }
 
 void LilygoT547Sensor::update() {

--- a/esphome/components/lilygo_t5_47/sensor/lilygo_t5_47_sensor.h
+++ b/esphome/components/lilygo_t5_47/sensor/lilygo_t5_47_sensor.h
@@ -2,8 +2,8 @@
 
 #include <Arduino.h>
 
-#include <driver/adc.h>
-#include "esp_adc_cal.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"


### PR DESCRIPTION
# What does this implement/fix?

Fixes some compatibility issues introduced with changes in ESPHome 2023.12.0

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
