### PR TITLE
Fix for esphome 2023.12.x - remaining fix

### DIFF
--- a/esphome/components/lilygo_t5_47/display/__init__.py
+++ b/esphome/components/lilygo_t5_47/display/__init__.py
@@ -45,7 +45,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 

--- a/esphome/components/lilygo_t5_47/display/__init__.py
+++ b/esphome/components/lilygo_t5_47/display/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_PAGES,
 )
+from esphome.const import __version__ as ESPHOME_VERSION
 
 from .. import lilygo_t5_47_ns
 
@@ -33,7 +34,9 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
+        
     await display.register_display(var, config)
 
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))

--- a/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
+++ b/esphome/components/lilygo_t5_47/display/lilygo_t5_47_display.h
@@ -11,7 +11,11 @@
 namespace esphome {
 namespace lilygo_t5_47 {
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class LilygoT547Display : public display::DisplayBuffer {
+#else 
 class LilygoT547Display : public PollingComponent, public display::DisplayBuffer {
+#endif
  public:
   float get_setup_priority() const override;
 


### PR DESCRIPTION
# What does this implement/fix?
Rename display.DisplayBufferRef was missing in previous PR

<!-- Quick description and explanation of changes -->

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/ashald/esphome/pull/4/files



## Test Environment

- [x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040



## Checklist:
  - [ x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

### This is a fix on compile error:
*AttributeError: module 'esphome.components.display' has no attribute 'DisplayBufferRef'. Did you mean: 'DisplayBuffer'?*